### PR TITLE
Fix redirect to dedicated thank-you page

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -24,12 +24,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Enviamos
     if (mail($to, $subject, $body, $headers)) {
-        // Redirigimos de vuelta con parámetro de éxito
-        header('Location: index.html?enviado=1#contacto');
+        // Redirigimos a la página de agradecimiento
+        header('Location: gracias.html');
         exit;
     } else {
         // Redirigimos con error
-        header('Location: index.html?enviado=0#contacto');
+        header('Location: index.php?enviado=0#contacto');
         exit;
     }
 }

--- a/index.php
+++ b/index.php
@@ -271,13 +271,9 @@
     <h2 class="center">Hablemos</h2>
     <p class="center">Cuéntanos qué necesitas y te responderemos en menos de 24 horas.</p>
 
-    <!-- Mostrar mensaje tras enviar -->
-    <?php if (isset($_GET['enviado'])): ?>
-      <?php if ($_GET['enviado'] == '1'): ?>
-        <div class="alert success">¡Gracias! Nos pondremos en contacto contigo.</div>
-      <?php else: ?>
-        <div class="alert error">Error al enviar el mensaje. Por favor, inténtalo de nuevo más tarde.</div>
-      <?php endif; ?>
+    <!-- Mostrar mensaje de error -->
+    <?php if (isset($_GET['enviado']) && $_GET['enviado'] == '0'): ?>
+      <div class="alert error">Error al enviar el mensaje. Por favor, inténtalo de nuevo más tarde.</div>
     <?php endif; ?>
 
     <form action="contact.php" method="post" class="mt-3">


### PR DESCRIPTION
## Summary
- redirect successful form submissions to `gracias.html`
- remove in-page success message from `index.php`
- keep error alert on main page

## Testing
- `php -l contact.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68827489ae28832e87c222904d8ab4f6